### PR TITLE
他ユーザーからのアクセスを制限するためポリシーを作成

### DIFF
--- a/app/Http/Controllers/AdditionController.php
+++ b/app/Http/Controllers/AdditionController.php
@@ -76,6 +76,8 @@ class AdditionController extends Controller
 
     public function edit(Query $query, Answer $answer, Addition $addition)
     {
+        $this->authorize('update', $addition);
+
         $addition_editing = true;
         $edit_addition_id = $addition->id;
         $answer_id = $addition->answer->id;
@@ -93,6 +95,8 @@ class AdditionController extends Controller
 
     public function update(Request $request, Query $query, $answer, Addition $addition)
     {
+        $this->authorize('update', $addition);
+
         $request->validate([
             "addition_content{$answer->id}" => 'required|min:5|max:300',
         ], [
@@ -111,6 +115,8 @@ class AdditionController extends Controller
 
     public function destroy(Query $query, $answer, Addition $addition)
     {
+        $this->authorize('delete', $addition);
+
         $answer;
         $addition->delete();
 

--- a/app/Http/Controllers/AnswerController.php
+++ b/app/Http/Controllers/AnswerController.php
@@ -53,6 +53,8 @@ class AnswerController extends Controller
 
     public function edit(Query $query, Answer $answer)
     {
+        $this->authorize('update', $answer);
+
         $editing = true;
         $edit_answer_id = $answer->id;
 
@@ -69,6 +71,8 @@ class AnswerController extends Controller
 
     public function update(AnswerRequest $request, Query $query, Answer $answer)
     {
+        $this->authorize('update', $answer);
+
         $answer->content = $request->input('answer_content');
         $answer->save();
 
@@ -79,6 +83,8 @@ class AnswerController extends Controller
 
     public function destroy(Query $query, Answer $answer)
     {
+        $this->authorize('delete', $answer);
+
         $answer->delete();
 
         return redirect()

--- a/app/Http/Controllers/QueryController.php
+++ b/app/Http/Controllers/QueryController.php
@@ -91,12 +91,16 @@ class QueryController extends Controller
 
     public function edit(Query $query)
     {
+        $this->authorize('update', $query);
+
         return view('queries.edit')
             ->with(['query' => $query]);
     }
 
     public function update(QueryRequest $request, Query $query)
     {
+        $this->authorize('update', $query);
+
         $query->title = $request->title;
         $query->content = $request->content;
         $query->save();
@@ -108,6 +112,8 @@ class QueryController extends Controller
 
     public function destroy(Query $query)
     {
+        $this->authorize('delete', $query);
+
         $query->delete();
 
         return redirect()

--- a/app/Policies/AdditionPolicy.php
+++ b/app/Policies/AdditionPolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Addition;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class AdditionPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Addition $addition): bool
+    {
+        return $user->id === $addition->user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Addition $addition): bool
+    {
+        return $user->id === $addition->user->id;
+    }
+}

--- a/app/Policies/AnswerPolicy.php
+++ b/app/Policies/AnswerPolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Answer;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class AnswerPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Answer $answer): bool
+    {
+        return $user->id === $answer->user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Answer $answer): bool
+    {
+        return $user->id === $answer->user->id;
+    }
+}

--- a/app/Policies/QueryPolicy.php
+++ b/app/Policies/QueryPolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Query;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class QueryPolicy
+{
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Query $query): bool
+    {
+        return $user->id === $query->user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Query $query): bool
+    {
+        return $user->id === $query->user->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,14 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\App;
+use App\Policies\QueryPolicy;
+use App\Policies\AnswerPolicy;
+use App\Policies\AdditionPolicy;
+use App\Models\Query;
+use App\Models\Answer;
+use App\Models\Addition;
+use App\Models\User;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +21,9 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        Query::class => QueryPolicy::class,
+        Answer::class => AnswerPolicy::class,
+        Addition::class => AdditionPolicy::class,
     ];
 
     /**


### PR DESCRIPTION
【概要】
他ユーザーからのアクセスを制限するためポリシーを作成

【変更点】
ログイン済みであれば、他のユーザーの質問、回答、補足に不正にアクセスされてしまう恐れがある為、
Edit、Update、Deleteアクションに認可ポリシーを実装しました。