### PR TITLE
質問の未解決・解決済の切り替え機能の実装

### DIFF
--- a/app/Http/Controllers/QueryController.php
+++ b/app/Http/Controllers/QueryController.php
@@ -89,6 +89,25 @@ class QueryController extends Controller
             ->with('flash_message', '質問を投稿しました');
     }
 
+    public function toggleResolve(Query $query)
+    {
+        $this->authorize('update', $query);
+
+        if ($query->resolve == 1) {
+            $query->resolve = 0;
+            $flash_message = '質問を未解決に変更しました';
+        } else {
+            $query->resolve = 1;
+            $flash_message = '質問を解決済に変更しました';
+        }
+        $query->timestamps = false;
+        $query->save();
+
+        return redirect()
+            ->route('queries.show', $query)
+            ->with('flash_message', $flash_message);
+    }
+
     public function edit(Query $query)
     {
         $this->authorize('update', $query);

--- a/app/Http/Controllers/QueryController.php
+++ b/app/Http/Controllers/QueryController.php
@@ -9,6 +9,22 @@ use App\Http\Requests\QueryRequest;
 
 class QueryController extends Controller
 {
+    private function getQueriesByResolveStatus(Request $request, $resolveStatus)
+    {
+        $search = $request->input('search');
+        $queryBuilder = Query::where('resolve', $resolveStatus)
+            ->orderBy('updated_at', 'DESC');
+
+        if ($search) {
+            $queryBuilder->where(function ($query) use ($search) {
+                $query->where('title', 'like', "%{$search}%")
+                    ->orWhere('content', 'like', "%{$search}%");
+            });
+        }
+
+        return $queryBuilder->orderBy('updated_at', 'DESC')->paginate(5);
+    }
+
     public function index(Request $request)
     {
         $queries = Query::orderBy('updated_at', 'DESC');
@@ -55,6 +71,34 @@ class QueryController extends Controller
                 'search' => $search,
                 'controller' => 'queries',
                 'method' => 'my_queries',
+            ]);
+    }
+
+    public function resolvedQueries(Request $request)
+    {
+        $queries = $this->getQueriesByResolveStatus($request, 1);
+
+        return view('queries.index')
+            ->with([
+                'queries' => $queries,
+                'title' => '解決済の質問',
+                'search' => $request->input('search'),
+                'controller' => 'queries',
+                'method' => 'resolved_queries',
+            ]);
+    }
+
+    public function unresolvedQueries(Request $request)
+    {
+        $queries = $this->getQueriesByResolveStatus($request, 0);
+
+        return view('queries.index')
+            ->with([
+                'queries' => $queries,
+                'title' => '未解決の質問',
+                'search' => $request->input('search'),
+                'controller' => 'queries',
+                'method' => 'unresolved_queries',
             ]);
     }
 

--- a/database/migrations/2023_09_23_191844_add_boolean_column_to_answer.php
+++ b/database/migrations/2023_09_23_191844_add_boolean_column_to_answer.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('queries', function (Blueprint $table) {
+            $table->boolean('resolve')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('queries', function (Blueprint $table) {
+            $table->dropColumn('resolve');
+        });
+    }
+};

--- a/public/js/flash-message.js
+++ b/public/js/flash-message.js
@@ -21,7 +21,7 @@
                 animation.onfinish = function () {
                     flash.style.display = 'none';
                 };
-            }, 3000);
+            }, 2000);
         }
     };
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -18,11 +18,11 @@
                     <x-nav-link :href="route('queries.my_queries')" :active="request()->routeIs('queries.my_queries')">
                         自分の質問
                     </x-nav-link>
-                    <x-nav-link :href="route('answers.index')" :active="request()->routeIs('answers.index')">
-                        回答した質問
+                    <x-nav-link :href="route('queries.resolved_queries')" :active="request()->routeIs('queries.resolved_queries')">
+                        解決済の質問
                     </x-nav-link>
-                    <x-nav-link :href="route('additions.index')" :active="request()->routeIs('additions.index')">
-                        補足した質問
+                    <x-nav-link :href="route('queries.unresolved_queries')" :active="request()->routeIs('queries.unresolved_queries')">
+                        未解決の質問
                     </x-nav-link>
                 </div>
             </div>
@@ -44,6 +44,13 @@
                         </x-slot>
 
                         <x-slot name="content">
+                            <x-dropdown-link :href="route('answers.index')">
+                                回答した質問
+                            </x-dropdown-link>
+                            <x-dropdown-link :href="route('additions.index')">
+                                補足した質問
+                            </x-dropdown-link>
+                            <hr class="border-gray-500">
                             <x-dropdown-link :href="route('profile.edit')">
                                 {{ __('Profile') }}
                             </x-dropdown-link>
@@ -101,13 +108,19 @@
                     <x-responsive-nav-link :href="route('queries.my_queries')">
                         自分の質問
                     </x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('queries.resolved_queries')">
+                        解決済の質問
+                    </x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('queries.unresolved_queries')">
+                        未解決の質問
+                    </x-responsive-nav-link>
                     <x-responsive-nav-link :href="route('answers.index')">
                         回答した質問
                     </x-responsive-nav-link>
                     <x-responsive-nav-link :href="route('additions.index')">
                         補足した質問
                     </x-responsive-nav-link>
-
+                    <hr class="border-gray-500">
                     <x-responsive-nav-link :href="route('profile.edit')">
                         {{ __('Profile') }}
                     </x-responsive-nav-link>

--- a/resources/views/queries/show.blade.php
+++ b/resources/views/queries/show.blade.php
@@ -32,21 +32,39 @@
             {{-- 質問本文 --}}
             <div class="block min-h-[400px] p-6 bg-white border-[2px] border-gray-200 rounded-lg shadow-md dark:bg-slate-900 dark:border-gray-700">
                 <h2 class="mb-4 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{{ $query->title }}</h2>
-                <div class="flex flex-col justify-between mb-6 md:flex-row">
-                    <div class="mb-1">
-                        <p class="font-bold text-gray-700 dark:text-gray-300">
+                <div class="flex justify-between mb-4 md:flex-row">
+                    <div>
+                        <p class="font-bold text-gray-700 dark:text-gray-300 mb-1">
                             投稿者： {{ $query->user->name }}
                         </p>
-                    </div>
-                    <div>
-                        <p class="text-sm font-mono text-gray-700 dark:text-gray-400">
-                            作成日時： {{ $query->created_at }}
-                        </p>
-                        @if ($query->created_at != $query->updated_at)
+                        <div>
                             <p class="text-sm font-mono text-gray-700 dark:text-gray-400">
-                                更新日時： {{ $query->updated_at }}
+                                投稿： {{ $query->created_at }}
                             </p>
-                        @endif
+                            @if ($query->created_at != $query->updated_at)
+                                <p class="text-sm font-mono text-gray-700 dark:text-gray-400">
+                                    更新： {{ $query->updated_at }}
+                                </p>
+                            @endif
+                        </div>
+                    </div>
+                    <div class="text-center">
+                        <div class="mb-3">
+                            @if ($query->resolve)
+                                <p class="text-green-500 font-bold border border-green-500 px-2 py-1 rounded-md">解決済</p>
+                            @else
+                                <p class="text-orange-500 font-bold border border-orange-500 px-2 py-1 rounded-md">未解決</p>
+                            @endif
+                        </div>
+                        @can('update', $query)
+                            <div class="text-sm text-blue-500 hover:underline">
+                                @if ($query->resolve)
+                                    <a href="{{ route('queries.resolve', $query) }}">未解決にする</a>
+                                @else
+                                    <a href="{{ route('queries.resolve', $query) }}">解決済にする</a>
+                                @endif
+                            </div>
+                        @endcan
                     </div>
                 </div>
                 <p class="font-normal text-gray-100 dark:text-gray-100">
@@ -70,11 +88,11 @@
                             </div>
                             <div>
                                 <p class="text-sm font-mono text-gray-700 dark:text-gray-400">
-                                    投稿日時: {{ $answer->created_at }}
+                                    投稿: {{ $answer->created_at }}
                                 </p>
                                 @if ($answer->created_at != $answer->updated_at)
                                     <p class="text-sm font-mono text-gray-700 dark:text-gray-400">
-                                        更新日時: {{ $answer->updated_at }}
+                                        更新: {{ $answer->updated_at }}
                                     </p>
                                 @endif
                             </div>
@@ -163,11 +181,11 @@
                                             </div>
                                             <div>
                                                 <p class="text-xs font-mono text-gray-700 dark:text-gray-400">
-                                                    投稿日時: {{ $addition->created_at }}
+                                                    投稿: {{ $addition->created_at }}
                                                 </p>
                                                 @if ($addition->created_at != $addition->updated_at)
                                                     <p class="text-xs font-mono text-gray-700 dark:text-gray-400">
-                                                        更新日時: {{ $addition->updated_at }}
+                                                        更新: {{ $addition->updated_at }}
                                                     </p>
                                                 @endif
                                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,10 @@ Route::middleware('auth')->group(function () {
         ->name('answers.index');
     Route::get('/additions_queries', [AdditionController::class, 'index']) //補足した質問ページ
         ->name('additions.index');
+    Route::get('/resolved_queries', [QueryController::class, 'resolvedQueries']) //解決済の質問ページ
+        ->name('queries.resolved_queries');
+    Route::get('/unresolved_queries', [QueryController::class, 'unresolvedQueries']) //未解決の質問ページ
+        ->name('queries.unresolved_queries');
 
     Route::resource('queries', QueryController::class); //質問CRUD
     Route::get('/queries/{query}/resolve', [QueryController::class, 'toggleResolve'])->name('queries.resolve'); //解決トグル

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware('auth')->group(function () {
         ->name('additions.index');
 
     Route::resource('queries', QueryController::class); //質問CRUD
+    Route::get('/queries/{query}/resolve', [QueryController::class, 'toggleResolve'])->name('queries.resolve'); //解決トグル
 
     Route::post('/queries/{query}/answers', [AnswerController::class, 'store']) //回答C
         ->name('answers.store');


### PR DESCRIPTION
【概要】
質問の未解決・解決済の切り替え機能の実装を行った。

【変更点】
・質問詳細ページに未解決・解決トグル＆表示を追加
・未解決・解決済の質問一覧ページを追加

【今後の課題点】
・質問や回答に対するいいね機能の実装
・ゲストユーザーログイン機能の実装